### PR TITLE
Add tests for week-3/02-course-app-easy

### DIFF
--- a/week-3/02-course-app-easy/index.test.js
+++ b/week-3/02-course-app-easy/index.test.js
@@ -1,0 +1,461 @@
+const http = require('http');
+const server = require('./index');
+
+const admin = {
+  username: 'TestAdmin',
+  password: 'TestAdminPass',
+};
+
+const user = {
+  username: 'TestUser',
+  password: 'TestUserPass',
+};
+
+describe('API Tests', () => {
+  let globalServer;
+  let courseId;
+
+  beforeAll((done) => {
+    if (globalServer) {
+      globalServer.close();
+    }
+    globalServer = server.listen(3000);
+    done();
+  });
+
+  afterAll((done) => {
+    globalServer.close(done);
+  });
+
+  it('should allow admins to signup', async () => {
+    const requestBody = JSON.stringify({
+      username: admin.username,
+      password: admin.password,
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/admin/signup',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Admin created successfully' })
+    );
+  });
+
+  it("shouldn't allow duplicate usernames for admins", async () => {
+    const requestBody = JSON.stringify({
+      username: admin.username,
+      password: admin.password,
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/admin/signup',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Admin already exists' })
+    );
+  });
+
+  it('should allow admins to login', async () => {
+    const options = {
+      method: 'POST',
+      path: '/admin/login',
+      headers: {
+        'Content-Type': 'application/json',
+        username: admin.username,
+        password: admin.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Logged in successfully' })
+    );
+  });
+
+  it("shouldn't allow admins to login on invalid credentials", async () => {
+    const requestBody = JSON.stringify({
+      username: admin.username,
+      password: 'incorrectPass',
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/admin/login',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Admin authentication failed' })
+    );
+  });
+
+  it("shouldn't allow admins to login with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: admin.username });
+
+    const options = {
+      method: 'POST',
+      path: '/admin/login',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Admin authentication failed' })
+    );
+  });
+
+  it('should allow admins to create courses', async () => {
+    const requestBody = JSON.stringify({
+      title: 'course title',
+      description: 'course description',
+      price: 100,
+      imageLink: 'https://linktoimage.com',
+      published: true,
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/admin/courses',
+      headers: {
+        'Content-Type': 'application/json',
+        username: admin.username,
+        password: admin.password,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+
+    const responseBody = JSON.parse(response.body);
+
+    expect(responseBody.message).toBe('Course created successfully');
+    expect(responseBody.courseId).toBeTruthy();
+
+    courseId = responseBody.courseId;
+  });
+
+  it('should allow admins to update courses', async () => {
+    const requestBody = JSON.stringify({
+      title: 'updated course title',
+      description: 'updated course description',
+      price: 100,
+      imageLink: 'https://linktoimage.com',
+      published: true,
+    });
+
+    const options = {
+      method: 'PUT',
+      path: `/admin/courses/${courseId}`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: admin.username,
+        password: admin.password,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Course updated successfully' })
+    );
+  });
+
+  it('should send 404 on updating invalid courseId', async () => {
+    const requestBody = JSON.stringify({
+      title: 'updated course title',
+      description: 'updated course description',
+      price: 100,
+      imageLink: 'https://linktoimage.com',
+      published: true,
+    });
+
+    const options = {
+      method: 'PUT',
+      path: `/admin/courses/invald-course-id`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: admin.username,
+        password: admin.password,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('admins should get courses', async () => {
+    const options = {
+      method: 'GET',
+      path: `/admin/courses`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: admin.username,
+        password: admin.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).courses.length).toBeTruthy();
+  });
+
+  // USER API TESTS
+
+  it('should allow users to signup', async () => {
+    const requestBody = JSON.stringify({
+      username: user.username,
+      password: user.password,
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/users/signup',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'User created successfully' })
+    );
+  });
+
+  it('should allow users to login', async () => {
+    const options = {
+      method: 'POST',
+      path: '/users/login',
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Logged in successfully' })
+    );
+  });
+
+  it("shouldn't allow users to login on invalid credentials", async () => {
+    const requestBody = JSON.stringify({
+      username: user.username,
+      password: 'incorrectPass',
+    });
+
+    const options = {
+      method: 'POST',
+      path: '/users/login',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'User authentication failed' })
+    );
+  });
+
+  it("shouldn't allow users to login with bad request body", async () => {
+    const requestBody = JSON.stringify({ username: user.username });
+
+    const options = {
+      method: 'POST',
+      path: '/users/login',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'User authentication failed' })
+    );
+  });
+
+  it('users should be able to get all courses', async () => {
+    const options = {
+      method: 'GET',
+      path: `/users/courses`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+
+    const courses = JSON.parse(response.body).courses;
+
+    expect(courses.length).toBeTruthy();
+
+    courseId = courses[0].id;
+  });
+
+  it('should allow users to purchase courses', async () => {
+    const options = {
+      method: 'POST',
+      path: `/users/courses/${courseId}`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+
+    const responseBody = JSON.parse(response.body);
+
+    expect(responseBody.message).toBe('Course purchased successfully');
+  });
+
+  it('should send 404 on purchasing course with invalid courseId', async () => {
+    const options = {
+      method: 'POST',
+      path: `/users/courses/invald-course-id`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(404);
+
+    expect(response.body).toBe(
+      JSON.stringify({ message: 'Course not found or not available' })
+    );
+  });
+
+  it('should allow users to get purchased courses', async () => {
+    const options = {
+      method: 'GET',
+      path: `/users/purchasedCourses`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).purchasedCourses.length).toBeTruthy();
+  });
+
+  it("shouldn't allow users to access admin routes", async () => {
+    const requestBody = JSON.stringify({
+      title: 'updated course title',
+      description: 'updated course description',
+      price: 100,
+      imageLink: 'https://linktoimage.com',
+      published: true,
+    });
+
+    const options = {
+      method: 'PUT',
+      path: `/admin/courses/${courseId}`,
+      headers: {
+        'Content-Type': 'application/json',
+        username: user.username,
+        password: user.password,
+      },
+    };
+
+    const response = await sendRequest(options, requestBody);
+
+    expect(response.statusCode).toBe(403);
+  });
+});
+
+function sendRequest(options, requestBody) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        ...options,
+        host: 'localhost',
+        port: 3000,
+      },
+      (res) => {
+        let body = '';
+
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body,
+          });
+        });
+      }
+    );
+
+    req.on('error', (err) => {
+      reject(err);
+    });
+
+    if (requestBody) {
+      req.write(requestBody);
+    }
+
+    req.end();
+  });
+}

--- a/week-3/02-course-app-easy/package.json
+++ b/week-3/02-course-app-easy/package.json
@@ -4,9 +4,15 @@
   "description": "### Description 1. Admins should be able to sign up 2. Admins should be able to create courses    1. Course has a title, description, price, and image link    2. Course should be able to be published or unpublished 3. Admins should be able to edit courses 4. Users should be able to sign up 5. Users should be able to purchase courses 6. Users should be able to view purchased courses 7. Users should be able to view all courses",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/jest/bin/jest.js ./index.test.js"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.5.0"
+  }
 }

--- a/week-3/solutions/02-course-app-easy.js
+++ b/week-3/solutions/02-course-app-easy.js
@@ -119,6 +119,11 @@ app.get('/users/purchasedCourses', userAuthentication, (req, res) => {
   res.json({ purchasedCourses });
 });
 
-app.listen(3000, () => {
-  console.log('Server is listening on port 3000');
-});
+// Below app.listen should be commented while running the tests
+// Uncomment below to start server and test with postman
+
+// app.listen(3000, () => {
+//   console.log('Server is listening on port 3000');
+// });
+
+module.exports = app


### PR DESCRIPTION
This MR adds the following tests to week-3/02-course-app-easy

1. should allow admins to signup
2. shouldn't allow duplicate usernames for admins
3. should allow admins to login
4. shouldn't allow admins to login on invalid credentials
5. shouldn't allow admins to login with bad request body
6. should allow admins to create courses
7. should allow admins to update courses
8. should send 404 on updating invalid courseId
9. admins should get courses
10. should allow users to signup
11. should allow users to login
12. shouldn't allow users to login on invalid credentials
13. shouldn't allow users to login with bad request body
14. users should be able to get all courses
15. should allow users to purchase courses
16. should send 404 on purchasing course with invalid courseId
17. should allow users to get purchased courses
18. shouldn't allow users to access admin routes