### PR TITLE
Remove Username from Headers in API Request

### DIFF
--- a/week-3/Course selling app.postman_collection.json
+++ b/week-3/Course selling app.postman_collection.json
@@ -263,11 +263,6 @@
 						"method": "POST",
 						"header": [
 							{
-								"key": "username",
-								"value": "harkirat@gmail.com",
-								"type": "text"
-							},
-							{
 								"key": "Authorization",
 								"value": "Bearer ",
 								"type": "text"


### PR DESCRIPTION
In the provided Postman JSON file, specifically the API request that accepts an Authorization token (JWT) in the headers. It appears that there was an unintended inclusion of the username in the headers.